### PR TITLE
changed back to list for this old version of Python/Wagtail

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -51,10 +51,10 @@ class SectionPage(Page):
 
     # Search index configuraiton
 
-    search_fields = Page.search_fields + [
+    search_fields = Page.search_fields + (
         index.SearchField('body'),
         index.FilterField('date'),
-    ]
+    )
 
 
     # Editor panels configuration


### PR DESCRIPTION
From old docs:
For the 1.5 release of Wagtail, the search_fields attribute on the Page models (and other searchable models) changed from a tuple to a list.

Issue to be created to upgrade Python and Wagtail version